### PR TITLE
Autonomous bootloader integration [2/2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,11 +237,8 @@ endif
 $(BUILD_DIR)/apps/.apps_done: $(APPS)
 
 
-loader:  libbsp
-	$(Q)$(MAKE) -C $@ EXTRA_CFLAGS="-DLOADER"
-
-libbsp:
-	ADAKERNEL= make LOADER=y -C kernel/src/arch
+loader:
+	$(Q)$(MAKE) -C $@
 
 $(APPS):
 	$(Q)$(MAKE) -C $@


### PR DESCRIPTION
## autonomous bootloader integration: cleaning

This patch delete the previously required libbsp dependency for bootloader build.
The bootloader update (included in  [bootloader PR1](https://github.com/wookey-project/bootloader/pull/1)) does not rely any more on this.

**Warn**: this PR dependson PR [Autonomous bootloader integration [1/2]](https://github.com/wookey-project/bootloader/pull/1)