### PR TITLE
[bugfix] avoid building java dependencies for firmware build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -777,7 +777,7 @@ verify: verify_check $(call all_verify_rules_fn, $(toverify))
 #
 #
 
-javacard_compile:
+javacard_compile: externals_java
 	@cd javacard && make applet_auth
 	@cd javacard && make applet_dfu
 ifeq ("$(USE_SIG_TOKEN)","USE_SIG_TOKEN")
@@ -803,7 +803,7 @@ javacard_push: javacard_push_auth javacard_push_dfu
 endif
 
 
-javacard: externals_java javacard_compile javacard_push
+javacard: javacard_compile javacard_push
 
 externals_java:
 	@make -C externals java

--- a/Makefile
+++ b/Makefile
@@ -200,10 +200,10 @@ layout: $(MEM_LAYOUT_DEF)
 # make prepare and make menuconfig to create the
 # .config file.
 
-.PHONY: libs drivers prepare loader prove externals $(APPS) $(APPS_PATHS) $(BUILD_LIBECC_DIR) $(BUILD_DIR)
+.PHONY: libs drivers prepare loader prove $(APPS) $(APPS_PATHS) $(BUILD_LIBECC_DIR) $(BUILD_DIR)
 
 
-applet: externals
+applet: externals_java externals_libs
 	$(Q)$(MAKE) -C javacard $@
 
 $(BUILD_DIR)/kernel/kernel.fw1.hex: $(BUILD_DIR)/apps/.apps_done
@@ -271,9 +271,9 @@ prove:
 # from all elf, finalize into one single binary file
 $(BUILD_DIR)/loader/loader.hex: libs loader
 
-$(APPS_FW1_HEXFILES): layout externals libs drivers $(APPS)
+$(APPS_FW1_HEXFILES): layout externals_libs libs drivers $(APPS)
 
-$(APPS_FW2_HEXFILES): layout externals libs drivers $(APPS)
+$(APPS_FW2_HEXFILES): layout externals_libs libs drivers $(APPS)
 
 libs:
 	$(Q)$(MAKE) -C libs all
@@ -803,8 +803,11 @@ javacard_push: javacard_push_auth javacard_push_dfu
 endif
 
 
-javacard: externals javacard_compile javacard_push
+javacard: externals_java javacard_compile javacard_push
 
-externals:
-	@make -C $@ all
+externals_java:
+	@make -C externals java
+
+externals_libs:
+	@make -C externals libs
 

--- a/externals/Makefile
+++ b/externals/Makefile
@@ -21,22 +21,23 @@ KEY2HEADER       = $(PROJ_FILES)/tools/key2header.py
 ##########################################
 ##### Libecc cryptographic library
 
-external_targets :=
+external_java_targets :=
+external_libs_targets :=
 
 ifeq ($(CONFIG_USR_LIB_SIGN),y)
-external_targets += libsign $(EC_UTILS)
+external_libs_targets += libsign $(EC_UTILS)
 endif
 
 ifeq ($(CONFIG_EXT_GP_PRO),y)
-external_targets += gp
+external_java_targets += gp
 endif
 
 ifeq ($(CONFIG_EXT_ANT_JAVACARD),y)
-external_targets += antjavacard
+external_java_targets += antjavacard
 endif
 
 ifeq ($(CONFIG_EXT_SECAES),y)
-external_targets += secaes
+external_libs_targets += secaes
 endif
 
 ifeq ($(USE_LLVM),y)
@@ -45,7 +46,11 @@ else
 HOST_CC=gcc
 endif
 
-all: $(external_targets)
+all: java libs
+
+java: $(external_java_targets)
+
+libs: $(external_libs_targets)
 
 gp:
 	if test ! -f $(PROJ_FILES)/javacard/applet/gp.jar; then \


### PR DESCRIPTION
This PR remove the build of java dependencies (global platform tools) when building the firmware.
GP tools are required for the applets build and needs to be compiled only when calling the javacard target.

This patch reduce this build dependency only to this target.