### PR TITLE
[enhancement] The firmware encryption master key is now 64 bytes in o…

### DIFF
--- a/tools/crypto_utils.py
+++ b/tools/crypto_utils.py
@@ -299,8 +299,8 @@ def decrypt_platform_data(encrypted_platform_bin_file, pin, data_type, override_
     if (len(data) > index):
         firmware_sig_priv_key_data = data[index:index+35]
         index += 35
-        firmware_sig_sym_key_data = data[index:index+32]
-        index += 32
+        firmware_sig_sym_key_data = data[index:index+64]
+        index += 64
         encrypted_local_pet_key_data = data[index:index+64]
         index += 64
     # Derive the decryption key

--- a/tools/encrypt_sign_firmware.py
+++ b/tools/encrypt_sign_firmware.py
@@ -184,8 +184,8 @@ if __name__ == '__main__':
     else:
         # Generate random
         sig_session_iv = gen_rand_string(16)
-        # Compute the HMAC, and concatenate them
-        hm = local_hmac.new(dec_firmware_sig_sym_key_data, digestmod=hashlib.sha256)
+        # Compute the HMAC, and concatenate them, HMAC key is first 32 bytes of master key
+        hm = local_hmac.new(dec_firmware_sig_sym_key_data[:32], digestmod=hashlib.sha256)
         hm.update(header + firmware_chunk_size_str + sig_session_iv + sig)
         sig_session_iv += hm.digest()
 
@@ -215,7 +215,7 @@ if __name__ == '__main__':
                 print("Error:  SIG token APDU error ...")
                 sys.exit(-1)
         else:
-            aes_cbc_ctx = local_AES.new(dec_firmware_sig_sym_key_data[:16], AES.MODE_CBC, iv=dec_firmware_sig_sym_key_data[16:])
+            aes_cbc_ctx = local_AES.new(dec_firmware_sig_sym_key_data[32:32+16], AES.MODE_CBC, iv=dec_firmware_sig_sym_key_data[32+16:])
             chunk_key = aes_cbc_ctx.encrypt(local_key_to_derive)
 
             # Increment the session iv

--- a/tools/gen_keys.py
+++ b/tools/gen_keys.py
@@ -214,7 +214,7 @@ if __name__ == '__main__':
     ## Master encryption key in the AUTH token
     save_in_file(gen_rand_string(32), AUTH_TOKEN_PATH+"/master_symmetric_auth_key.bin")
     ## Master firmware encryption key shared between the DFU and SIG tokens
-    shared_master_dfu_sig = gen_rand_string(32)
+    shared_master_dfu_sig = gen_rand_string(64)
     save_in_file(shared_master_dfu_sig, DFU_TOKEN_PATH+"/master_symmetric_dfu_key.bin")
     save_in_file(shared_master_dfu_sig, SIG_TOKEN_PATH+"/master_symmetric_sig_key.bin") 
     # Save salts


### PR DESCRIPTION
…rder to

properly split the HMAC key (first 32 bytes) and the AES-128-CBC key (bytes
32 to 48) and IV (bytes 48 to 64).

WARNING: this kind of breaks binary compatibility of old 'private' folders since
a key has been expanded.