### PR TITLE
[bugfix] force autoconf.h header generation after config updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ menuconfig: check-env
 	$(call cmd,mkincludedir)
 	$(call cmd,prepareada)
 	$(call cmd,menuconfig)
+	$(call cmd,update_autoconf)
 	$(call cmd,mkobjlist_libs)
 	$(call cmd,mkobjlist_apps)
 	$(call cmd,mkobjlist_drvs)

--- a/m_build.mk
+++ b/m_build.mk
@@ -176,7 +176,10 @@ quiet_cmd_distclean     = DISTCLEAN
 
 # about menuconfig, oldconfig and so on...
 quiet_cmd_menuconfig    = MENUCONFIG
-      cmd_menuconfig    = $(MCONF) Kconfig
+      cmd_menuconfig    = $(MCONF) Kconfig;
+	
+quiet_cmd_update_autoconf = UPDATE_AUTOCFG
+      cmd_update_autoconf = $(CONF) $(CONF_AUTO_ARGS) Kconfig
 
 quiet_cmd_mkincludedir  = MKINCLUDEDIR
       cmd_mkincludedir  = mkdir -p $(PWD)/include && mkdir -p $(PWD)/include/config $(PWD)/include/generated

--- a/m_config.mk
+++ b/m_config.mk
@@ -355,6 +355,7 @@ ifeq (, $(shell which kconfig-conf))
 MCONF            ?= menuconfig
 CONF             ?= olddefconfig
 CONF_ARGS        ?=
+CONF_AUTO_ARGS   ?=
 CONFGEN          ?= genconfig
 CONFGEN_ARGS     ?= --header-path include/generated/autoconf.h
 else
@@ -362,6 +363,7 @@ else
 MCONF            ?= kconfig-mconf
 CONF             ?= kconfig-conf
 CONF_ARGS        ?= --olddefconfig
+CONF_AUTO_ARGS   ?= --silentoldconfig
 CONFGEN          ?= true
 CONFGEN_ARGS     ?=
 endif


### PR DESCRIPTION
## update autoconf.h when calling menuconfig

   * request autoconf.h upgrade each time ```make menuconfig``` is called to upgrade the C header
