### PR TITLE
Includes

### DIFF
--- a/m_config.mk
+++ b/m_config.mk
@@ -211,7 +211,7 @@ APPS_CFLAGS    = $(USER_CFLAGS) $(LIB_INC_CFLAGS) $(DRV_INC_CFLAGS) $(CFLAGS_DRV
 # drivers have access to other drivers and to the libstd only
 DRIVERS_CFLAGS = $(USER_CFLAGS) $(DRV_INC_CFLAGS) $(CFLAGS_DRVLAYOUT) -I$(PROJ_FILES)/libs/std/api
 # libs have access to others libs and drivers
-LIBS_CFLAGS    = $(USER_CFLAGS) $(LIB_INC_CFLAGS) $(DRV_INC_CFLAGS)
+LIBS_CFLAGS    = $(USER_CFLAGS) $(LIB_INC_CFLAGS) $(CFLAGS_DRVLAYOUT) $(DRV_INC_CFLAGS)
 
 
 


### PR DESCRIPTION
Allows libraries to be informed of the bellowing hardware layout (device identifier access). This is needed for low level interaction between protocol stacks and device drivers.